### PR TITLE
Fix content inside .navbar-collapse

### DIFF
--- a/resources/views/layout/partials/header.edge
+++ b/resources/views/layout/partials/header.edge
@@ -11,7 +11,7 @@
     </button>
 
     {{-- Navigation --}}
-    <div class="collapse navbar-collapse d-flex justify-content-end" id="navbar">
+    <div class="collapse navbar-collapse justify-content-end" id="navbar">
       <ul class="navbar-nav">
         {{--
           This tag let us know if the current user is logged in or not.


### PR DESCRIPTION
Remove .d-flex from .navbar-collapse to fix mobile dropdown. Previously, the hamburger menu would appear, but the content inside the collapsed div was always visible due to the use of !important in .d-flex.